### PR TITLE
Fixes #2 show countdown for upcoming contents

### DIFF
--- a/resources/views/includes/video/player.blade.php
+++ b/resources/views/includes/video/player.blade.php
@@ -11,12 +11,69 @@
         : '' }}
     },
 }'>
+@php
+$releaseDateString = $isTv
+        ? ($video->first_air_date ?? null)
+        : ($video->release_date ?? null);
+$isInFuture = strtotime($releaseDateString ) > time();
+
+@endphp
+
+   @if(isset($isInFuture) && $isInFuture)
+        <div x-data="countdownTimer('{{ $releaseDateString }}')"
+             class="z-30 w-100 h-full relative justify-center flex flex-col items-center bg-primary-900/90 rounded-md shadow-2xl backdrop-blur-md">
+
+            <div x-show="!isExpired" class="text-center">
+                <span class="text-accent-400 text-sm font-semibold uppercase tracking-wider block mb-2">Releasing In</span>
+
+                <div class="flex items-center space-x-3 text-center">
+                    <div class="bg-primary-950 px-3 py-2 rounded-lg border border-primary-800">
+                        <span class="text-2xl font-bold text-white" x-text="days">00</span>
+                        <span class="block text-[10px] text-primary-400 uppercase font-medium">Days</span>
+                    </div>
+                    <span class="text-xl font-bold text-primary-400">:</span>
+                    <div class="bg-primary-950 px-3 py-2 rounded-lg border border-primary-800">
+                        <span class="text-2xl font-bold text-white" x-text="String(hours).padStart(2, '0')">00</span>
+                        <span class="block text-[10px] text-primary-400 uppercase font-medium">Hours</span>
+                    </div>
+                    <span class="text-xl font-bold text-primary-400">:</span>
+                    <div class="bg-primary-950 px-3 py-2 rounded-lg border border-primary-800">
+                        <span class="text-2xl font-bold text-white" x-text="String(minutes).padStart(2, '0')">00</span>
+                        <span class="block text-[10px] text-primary-400 uppercase font-medium">Mins</span>
+                    </div>
+                    <span class="text-xl font-bold text-primary-400">:</span>
+                    <div class="bg-primary-950 px-3 py-2 rounded-lg border border-primary-800">
+                        <span class="text-2xl font-bold text-white" x-text="String(seconds).padStart(2, '0')">00</span>
+                        <span class="block text-[10px] text-primary-400 uppercase font-medium">Secs</span>
+                    </div>
+                </div>
+            </div>
+
+            <button 
+                x-show="!isLoading && !isPlaying && isExpired" 
+                @click="playMovie(frameUrl())" 
+                x-cloak 
+                class="px-2 rounded-md position-center bg-primary-900 shadow-lg shadow-primary-950 z-30">
+                    <svg 
+                        xmlns="http://www.w3.org/2000/svg" 
+                        class="text-accent-400" 
+                        width="42" 
+                        height="42" 
+                        viewBox="0 0 24 24">
+                        <path fill="currentColor" d="M7 6v12l10-6z"></path>
+                    </svg>
+            </button>
+        </div>
+    @else
+
     <button x-show="!isLoading && !isPlaying" @click="playMovie(frameUrl())" x-cloak
         class="px-2 rounded-md position-center bg-primary-900 shadow-lg shadow-primary-950 z-30">
         <svg xmlns="http://www.w3.org/2000/svg" class="text-accent-400" width="42" height="42" viewBox="0 0 24 24">
             <path fill="currentColor" d="M7 6v12l10-6z"></path>
         </svg>
     </button>
+
+    @endif
     <div x-show="isLoading" x-cloak class="position-center z-30">
         <svg class="animate-spin -ml-1 mr-3 text-primary-50" xmlns="http://www.w3.org/2000/svg" fill="none"
             width="40" height="40" viewBox="0 0 24 24">
@@ -31,7 +88,7 @@
         class="absolute z-20 inset-0 w-full h-full bx-shadow"></div>
     <img :class="isPlaying && 'sm:blur-sm'" class="absolute inset-0 w-full h-full object-cover z-10"
         src="{{ $video->getImageUrl('w1280') . $video->backdrop_path }}" alt="">
-    <div x-show="isPlaying" x-cloak class="group container px-0 z-20 w-full h-full absolute inset-0">
+    <div x-show="isPlaying" x-cloak class="group container px-0 z-30 w-full h-full absolute inset-0">
         <button @click="cancelPlay()" x-show="closePlayer" x-cloak
             class="hidden group-hover:block absolute z-30 top-0 md:top-1 right-2 sm:right-5 md:right-10 p-1 md:p-2 hover:text-primary-300 left-auto text-primary-200">
             <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24">

--- a/resources/views/includes/video/player.blade.php
+++ b/resources/views/includes/video/player.blade.php
@@ -11,14 +11,6 @@
         : '' }}
     },
 }'>
-@php
-$releaseDateString = $isTv
-        ? ($video->first_air_date ?? null)
-        : ($video->release_date ?? null);
-$isInFuture = strtotime($releaseDateString ) > time();
-
-@endphp
-
    @if(isset($isInFuture) && $isInFuture)
         <div x-data="countdownTimer('{{ $releaseDateString }}')"
              class="z-30 w-100 h-full relative justify-center flex flex-col items-center bg-primary-900/90 rounded-md shadow-2xl backdrop-blur-md">

--- a/resources/views/video.blade.php
+++ b/resources/views/video.blade.php
@@ -10,7 +10,6 @@
         ? ($video->first_air_date ?? null)
         : ($video->release_date ?? null);
 
-
     $isInFuture = strtotime($releaseDateString ) > time();
 
     $runtime =
@@ -39,6 +38,8 @@
     $this->share('title', $title);
     $this->share('original_title', $original_title);
     $this->share('runtime', $runtime);
+    $this->share('releaseDateString', $releaseDateString);
+    $this->share('isInFuture', $isInFuture);
 @endphp
 
 @section('title', $title)

--- a/resources/views/video.blade.php
+++ b/resources/views/video.blade.php
@@ -1,11 +1,18 @@
 @php
-
     $isTv = isset($video->name) && !isset($video->title);
     $title = $isTv ? $video->name : $video->title;
 
     $title = "Watch $title Free Online in " . cms('title');
 
     $original_title = $isTv ? $video->original_name : $video->original_title;
+
+    $releaseDateString = $isTv
+        ? ($video->first_air_date ?? null)
+        : ($video->release_date ?? null);
+
+
+    $isInFuture = strtotime($releaseDateString ) > time();
+
     $runtime =
         $isTv && !empty($video->episode_run_time)
             ? array_sum($video->episode_run_time) / count($video->episode_run_time)
@@ -58,6 +65,44 @@
 
     </main>
     <script>
+        function countdownTimer(targetDateStr) {
+            return {
+                targetTimestamp: new Date(targetDateStr).getTime(),
+                days: 0,
+                hours: 0,
+                minutes: 0,
+                seconds: 0,
+                isExpired: false,
+                timer: null,
+
+                init() {
+                    this.update();
+                    this.timer = setInterval(() => {
+                        this.update();
+                    }, 1000);
+                },
+
+                update() {
+                    const now = new Date().getTime();
+                    const diff = this.targetTimestamp - now;
+
+                    if (diff <= 0) {
+                        this.isExpired = true;
+                        this.days = 0;
+                        this.hours = 0;
+                        this.minutes = 0;
+                        this.seconds = 0;
+                        clearInterval(this.timer);
+                        return;
+                    }
+
+                    this.days = Math.floor(diff / (1000 * 60 * 60 * 24));
+                    this.hours = Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+                    this.minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+                    this.seconds = Math.floor((diff % (1000 * 60)) / 1000);
+                }
+            };
+        }
         function videoInfo() {
             return {
                 isPlaying: false,


### PR DESCRIPTION
This PR add countdown for upcoming content (movies only, as series and upcoming episodes are not loaded anywhere). included recording of testing with different test cases👇

1. tested with fake release date (8s after current time)

https://github.com/user-attachments/assets/97b95a08-0f84-41e5-958b-5751bc0392fd


2. Tested with original data: Avenger Doomsday is set to release on December 2026 and Spider Brand New Day already released. So I tested with them if countdown shows or not for upcoming movie and if its hidden for already released movies.

https://github.com/user-attachments/assets/70cd7e70-4b99-48b8-ad10-fb70ff0112bd

Closes #2 
